### PR TITLE
FIX: Shared state between MapViews

### DIFF
--- a/components/SearchableLocationDropdown.tsx
+++ b/components/SearchableLocationDropdown.tsx
@@ -88,6 +88,7 @@ export const SearchableLocationDropdown = forwardRef(
 
     const onClearPress = useCallback(() => {
       setSuggestionsList(null);
+      setSelectedLocation(undefined);
     }, []);
 
     const onOpenSuggestionsList = useCallback((_isOpened: boolean) => {}, []);

--- a/context/MapContext.tsx
+++ b/context/MapContext.tsx
@@ -7,8 +7,8 @@ import { Location } from '../models/Location';
 interface MapContext {
   hotspots: Hotspot[];
   setHotspots: Dispatch<SetStateAction<Hotspot[]>>;
-  selectedLocation?: Location | null;
-  setSelectedLocation: Dispatch<SetStateAction<Location | undefined | null>>;
+  selectedLocation?: Location;
+  setSelectedLocation: Dispatch<SetStateAction<Location | undefined>>;
   selectedAddress?: string;
   setSelectedAddress: Dispatch<SetStateAction<string | undefined>>;
 }

--- a/context/MapContext.tsx
+++ b/context/MapContext.tsx
@@ -1,6 +1,13 @@
 import * as LocationProvider from 'expo-location';
 import { createContext, Dispatch, SetStateAction } from 'react';
+import { Region } from 'react-native-maps';
 import { googleMapsApiKey } from '../config';
+import {
+  initialLatitude,
+  initialLatitudeDelta,
+  initialLongitude,
+  initialLongitudeDelta,
+} from '../constants/location';
 import { Hotspot } from '../models/Hotspot';
 import { Location } from '../models/Location';
 
@@ -11,13 +18,22 @@ interface MapContext {
   setSelectedLocation: Dispatch<SetStateAction<Location | undefined>>;
   selectedAddress?: string;
   setSelectedAddress: Dispatch<SetStateAction<string | undefined>>;
+  region: Region;
+  setRegion: Dispatch<SetStateAction<Region>>;
 }
 
 export const MapContext = createContext<MapContext>({
   hotspots: [],
+  region: {
+    latitude: initialLatitude,
+    longitude: initialLongitude,
+    latitudeDelta: initialLatitudeDelta,
+    longitudeDelta: initialLongitudeDelta,
+  },
   setHotspots: () => {},
   setSelectedLocation: () => {},
   setSelectedAddress: () => {},
+  setRegion: () => {},
 });
 
 export const findCurrentLocation = async (

--- a/context/index.tsx
+++ b/context/index.tsx
@@ -1,4 +1,11 @@
 import { ReactNode, useMemo, useState } from 'react';
+import { Region } from 'react-native-maps';
+import {
+  initialLatitude,
+  initialLatitudeDelta,
+  initialLongitude,
+  initialLongitudeDelta,
+} from '../constants/location';
 import {
   defaultHotspotDetails,
   Hotspot,
@@ -26,20 +33,28 @@ export const AuthContextProvider = ({ children }: { children: ReactNode }) => {
 export const MapContextProvider = ({ children }: { children: ReactNode }) => {
   const [hotspots, setHotspots] = useState<Hotspot[]>([]);
   const [selectedLocation, setSelectedLocation] = useState<
-    Location | null | undefined
+    Location | undefined
   >();
   const [selectedAddress, setSelectedAddress] = useState<string | undefined>();
+  const [region, setRegion] = useState<Region>({
+    latitude: initialLatitude,
+    longitude: initialLongitude,
+    latitudeDelta: initialLatitudeDelta,
+    longitudeDelta: initialLongitudeDelta,
+  });
 
   const value = useMemo(
     () => ({
       hotspots,
-      setHotspots,
       selectedLocation,
-      setSelectedLocation,
       selectedAddress,
+      region,
+      setHotspots,
+      setSelectedLocation,
       setSelectedAddress,
+      setRegion,
     }),
-    [hotspots, selectedLocation, selectedAddress]
+    [hotspots, selectedLocation, selectedAddress, region]
   );
 
   return <MapContext.Provider value={value}>{children}</MapContext.Provider>;

--- a/screens/ChooseLocationScreen.tsx
+++ b/screens/ChooseLocationScreen.tsx
@@ -172,7 +172,7 @@ export const ChooseLocationScreen = ({
                 longitude: selectedLocation.longitude,
               }}
               onPress={() => {
-                setSelectedLocation(null);
+                setSelectedLocation(undefined);
               }}
             >
               <Image

--- a/screens/ChooseLocationScreen.tsx
+++ b/screens/ChooseLocationScreen.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import {
   Image,
   Platform,
@@ -25,7 +25,7 @@ import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
 import { Marker } from '../maps';
 import { getHotspotMarker } from '../models/Hotspot';
 import { getFormattedAddress, Location } from '../models/Location';
-import { EdgeInsets, Region, RootStackScreenProps } from '../types';
+import { EdgeInsets, RootStackScreenProps } from '../types';
 import SnackbarManager from '../utils/SnackbarManager';
 import { findPlaceDetails } from '../utils/hotspots';
 
@@ -37,8 +37,8 @@ export const ChooseLocationScreen = ({
     setSelectedLocation,
     setSelectedAddress,
     selectedLocation,
+    region,
   } = useContext(MapContext);
-  const [region, setRegion] = useState<Region>(route.params.region);
 
   const mapRef = useRef<MapView>(null);
   const navigation = useNavigation();
@@ -89,9 +89,6 @@ export const ChooseLocationScreen = ({
           // use intial region + animateToRegion instead of region as react state because
           // gestures don't work well https://github.com/react-native-maps/react-native-maps/issues/3639
           initialRegion={region}
-          onRegionChange={() => {
-            setRegion;
-          }}
           showsUserLocation
           showsMyLocationButton={false}
           style={styles.map}

--- a/screens/HotspotFormScreen.tsx
+++ b/screens/HotspotFormScreen.tsx
@@ -254,7 +254,7 @@ const getStyles = (theme: NucaCustomTheme) =>
 export const HotspotFormScreen = ({
   route,
 }: RootStackScreenProps<'AddHotspot'>) => {
-  const { hotspots, setHotspots } = useContext(MapContext);
+  const { hotspots, setHotspots, setSelectedLocation } = useContext(MapContext);
   const [isInProgress, setIsInProgress] = useState(false);
   const navigation = useNavigation();
 
@@ -323,6 +323,7 @@ export const HotspotFormScreen = ({
         isUpdate ? 'Editare reuşită' : 'Adăugare reuşită'
       );
       navigation.goBack();
+      setSelectedLocation(undefined);
       return { hotspot: newHotspot };
     } else {
       setIsInProgress(false);

--- a/screens/MapScreen.tsx
+++ b/screens/MapScreen.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import MapView from 'react-native-maps';
+import MapView, { Details } from 'react-native-maps';
 import { Caption, FAB, Title } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -14,12 +14,7 @@ import currentLocationIcon from '../assets/current-location.png';
 import { Appbar } from '../components/Appbar';
 import { FullScreenActivityIndicator } from '../components/FullScreenActivityIndicator';
 import { SearchableLocationDropdown } from '../components/SearchableLocationDropdown';
-import {
-  initialLatitude,
-  initialLatitudeDelta,
-  initialLongitude,
-  initialLongitudeDelta,
-} from '../constants/location';
+import { initialLatitude, initialLongitude } from '../constants/location';
 import { MapContext } from '../context';
 import { findCurrentLocation } from '../context/MapContext';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
@@ -30,13 +25,14 @@ import SnackbarManager from '../utils/SnackbarManager';
 import { loadHotspots } from '../utils/hotspots';
 
 export const MapScreen = () => {
-  const { hotspots, setHotspots, selectedLocation, setSelectedLocation } = useContext(MapContext);
-  const [region, setRegion] = useState<Region>({
-    latitude: initialLatitude,
-    longitude: initialLongitude,
-    latitudeDelta: initialLatitudeDelta,
-    longitudeDelta: initialLongitudeDelta,
-  });
+  const {
+    hotspots,
+    setHotspots,
+    selectedLocation,
+    setSelectedLocation,
+    region,
+    setRegion,
+  } = useContext(MapContext);
   const mapRef = useRef<MapView>(null);
   const navigation = useNavigation();
   const [isLoading, setIsLoading] = useState(false);
@@ -67,6 +63,9 @@ export const MapScreen = () => {
     );
   };
 
+  const onRegionChange = (region: Region, _details: Details) =>
+    setRegion(region);
+
   return (
     <>
       <Appbar />
@@ -80,11 +79,9 @@ export const MapScreen = () => {
           // use intial region + animateToRegion instead of region as react state because
           // gestures don't work well https://github.com/react-native-maps/react-native-maps/issues/3639
           initialRegion={region}
-          onRegionChange={() => {
-            setRegion;
-          }}
           showsUserLocation
           showsMyLocationButton={false}
+          onRegionChangeComplete={onRegionChange}
           style={styles.map}
         >
           {hotspots.map((h: Hotspot) => (

--- a/screens/MapScreen.tsx
+++ b/screens/MapScreen.tsx
@@ -25,14 +25,12 @@ import { findCurrentLocation } from '../context/MapContext';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
 import { Marker } from '../maps';
 import { getHotspotMarker, Hotspot } from '../models/Hotspot';
-import { Location } from '../models/Location';
 import { EdgeInsets, Region } from '../types';
 import SnackbarManager from '../utils/SnackbarManager';
 import { loadHotspots } from '../utils/hotspots';
 
 export const MapScreen = () => {
-  const { hotspots, setHotspots } = useContext(MapContext);
-  const [location, setLocation] = useState<Location>();
+  const { hotspots, setHotspots, selectedLocation, setSelectedLocation } = useContext(MapContext);
   const [region, setRegion] = useState<Region>({
     latitude: initialLatitude,
     longitude: initialLongitude,
@@ -127,7 +125,7 @@ export const MapScreen = () => {
         activeOpacity={0.9}
         onPress={() => {
           navigation.navigate('AddHotspot', {
-            location: location,
+            location: selectedLocation,
             region: region,
           });
         }}
@@ -145,16 +143,14 @@ export const MapScreen = () => {
         small
         onPress={async () => {
           const location = await findCurrentLocation(onMapRateLimitExceeded);
-          if (!!location) {
-            setLocation(location);
+          setSelectedLocation(location);
 
-            mapRef.current?.animateToRegion({
-              latitude: location.latitude,
-              longitude: location.longitude,
-              latitudeDelta: 0,
-              longitudeDelta: 0,
-            });
-          }
+          mapRef.current?.animateToRegion({
+            latitude: location?.latitude || initialLatitude,
+            longitude: location?.longitude || initialLongitude,
+            latitudeDelta: 0,
+            longitudeDelta: 0,
+          });
         }}
       />
       {isLoading && <FullScreenActivityIndicator />}


### PR DESCRIPTION
These changes should improve the way the app handles the selected map region between MapScreen and ChooseLocationScreen.
    
### Changes:

- `onRegionChange` was replaced with `onRegionChangeComplete`, due to the fact that `onRegionChange` is called continuously while the map is moved by the user. Unlike `onRegionChange`, `onRegionChangeComplete` is executed once the user stops moving the map, therefore it doesn’t cause any laggy behaviour such as the previously used prop.
- the `onRegionChange` behaviour is now removed from the `ChooseLocationScreen` (it was essentially redundant)
- we avoid keeping the map region focused on the region associated with a stale `selectedLocation` hotspot when switching between the `MapScreen` and `ChooseLocationScreen`:
    - the `selectedLocation` state is set to `undefined` once a location/hotspot is added through the `HotspotFormScreen`
    - the `selectedLocation` state is set to `undefined` when the user cancels/quits adding a hotspot