### PR TITLE
remove native button for centering map on user's location

### DIFF
--- a/screens/ChooseLocationScreen.tsx
+++ b/screens/ChooseLocationScreen.tsx
@@ -93,6 +93,7 @@ export const ChooseLocationScreen = ({
             setRegion;
           }}
           showsUserLocation
+          showsMyLocationButton={false}
           style={styles.map}
           //am incercat si cu asta, asta merge, dar nu face ceea ce vrem noi
           onRegionChangeComplete={async region => {

--- a/screens/MapScreen.tsx
+++ b/screens/MapScreen.tsx
@@ -96,6 +96,7 @@ export const MapScreen = () => {
             setRegion;
           }}
           showsUserLocation
+          showsMyLocationButton={false}
           style={styles.map}
         >
           {hotspots.map((h: Hotspot) => (


### PR DESCRIPTION
https://trello.com/c/WxEBuK4O/54-android-only-center-map-button-from-native-map-is-visible-behind-the-search-bar