### PR TITLE
Fix null email and wrongly formatted check-in/out date issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "expo-updates": "~0.24.11",
         "expo-web-browser": "~12.8.2",
         "lodash": "^4.17.21",
+        "moment": "^2.30.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-native": "0.73.4",
@@ -20325,6 +20326,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/moo": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "expo-updates": "~0.24.11",
     "expo-web-browser": "~12.8.2",
     "lodash": "^4.17.21",
+    "moment": "^2.30.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.73.4",

--- a/utils/server.ts
+++ b/utils/server.ts
@@ -1,4 +1,5 @@
 import * as SecureStore from 'expo-secure-store';
+import moment from 'moment';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { server } from '../config';
@@ -23,8 +24,16 @@ const objectToFormData = (
   Object.entries(obj).reduce((fd: FormData, [key, value]: [string, any]) => {
     const propName: string = parentKey ? `${parentKey}[${key}]` : key;
 
-    if (typeof value === 'object' && !(value instanceof File)) {
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !(value instanceof File) &&
+      !Date.parse(value)
+    ) {
       return objectToFormData(value, fd, propName);
+    } else if (Date.parse(value)) {
+      const formattedDate = moment(new Date(value)).format('YYYY-MM-DD');
+      fd.append(propName, formattedDate);
     } else if (Array.isArray(value)) {
       value.forEach((item: any, index: number) =>
         objectToFormData(item, fd, `${propName}[${index}]`)


### PR DESCRIPTION
The objToFormData function used to fail when updating a particular cat card due to the e-mail field containing a `null` value. Also, the dates selected in the calendar were not properly formatted as a `YYYY-MM-DD` date string (which seemed to be why the date was not updated/refreshed).

The objToFormData should obviously be refactored, but the nested ifs are probably created to handle conditions specifically for the media updates and they could be removed or somehow refactored if `any` types were not used.

__Before:__

https://github.com/crafting-software/nuca-mobile/assets/32801760/4b847e50-66c3-4ef0-b614-40fc62f21aca

__After:__

https://github.com/crafting-software/nuca-mobile/assets/32801760/df859361-19cc-4fd9-9656-f47822e2b44a


