### PR TITLE
FIX: Cat paw markers on web

### DIFF
--- a/components/Marker.tsx
+++ b/components/Marker.tsx
@@ -22,19 +22,16 @@ export const Marker = ({
   onPress,
   isMapReady,
 }: MarkerProps) => {
-  // Used only on Web, instead of the Pin component
-  const webIcon = isWeb() && {
-    // @ts-ignore
-    scaledSize: new google.maps.Size(width, height),
-    url: imageSource,
-  };
-
   return isWeb() ? (
     // @ts-ignore
     <MapView.Marker
       coordinate={coordinate}
       key={passthroughKey}
-      icon={webIcon}
+      icon={{
+        // @ts-ignore
+        scaledSize: new google.maps.Size(width, height),
+        url: imageSource,
+      }}
       onPress={onPress}
     />
   ) : (

--- a/components/Marker.tsx
+++ b/components/Marker.tsx
@@ -1,0 +1,58 @@
+import { Image, ImageSourcePropType } from 'react-native';
+import MapView, { Marker as NativeMarker } from 'react-native-maps';
+import { isWeb } from '../utils/platform';
+
+type PinProps = { height: number; width: number; image: ImageSourcePropType };
+
+type MarkerProps = {
+  passthroughKey?: any;
+  coordinate: { latitude: number; longitude: number };
+  height: number;
+  width: number;
+  imageSource: ImageSourcePropType | string;
+  onPress?: () => any;
+  isMapReady?: boolean;
+};
+export const Marker = ({
+  coordinate,
+  height,
+  width,
+  passthroughKey,
+  imageSource,
+  onPress,
+  isMapReady,
+}: MarkerProps) => {
+  // Used only on Web, instead of the Pin component
+  const webIcon = isWeb() && {
+    // @ts-ignore
+    scaledSize: new google.maps.Size(width, height),
+    url: imageSource,
+  };
+
+  return isWeb() ? (
+    // @ts-ignore
+    <MapView.Marker
+      coordinate={coordinate}
+      key={passthroughKey}
+      icon={webIcon}
+      onPress={onPress}
+    />
+  ) : (
+    <NativeMarker
+      coordinate={coordinate}
+      key={passthroughKey}
+      onPress={onPress}
+      tracksViewChanges={!isMapReady}
+    >
+      <Pin
+        image={imageSource as ImageSourcePropType}
+        height={height}
+        width={width}
+      />
+    </NativeMarker>
+  );
+};
+
+const Pin = ({ image, height, width }: PinProps) => (
+  <Image source={image} style={{ height, width }} />
+);

--- a/maps.ts
+++ b/maps.ts
@@ -1,5 +1,0 @@
-import { Platform } from 'react-native';
-import MapView, { Marker as NativeMarker } from 'react-native-maps';
-
-/* @ts-ignore */
-export const Marker = Platform.OS === 'web' ? MapView.Marker : NativeMarker;

--- a/models/Hotspot.ts
+++ b/models/Hotspot.ts
@@ -2,8 +2,15 @@ import { camelCase } from 'lodash';
 import doneMarker from '../assets/marker-done.png';
 import inProgressMarker from '../assets/marker-in-progress.png';
 import todoMarker from '../assets/marker-todo.png';
+import { isWeb } from '../utils/platform';
 import { castToCat, Cat } from './Cat';
 import { castToUser, User } from './User';
+
+const doneMarkerImage = isWeb() ? '/assets/assets/marker-done.png' : doneMarker;
+const inProgressMarkerImage = isWeb()
+  ? '/assets/assets/marker-in-progress.png'
+  : inProgressMarker;
+const todoMarkerImage = isWeb() ? '/assets/assets/marker-todo.png' : todoMarker;
 
 export enum HotspotStatus {
   toDo = 'în așteptare',
@@ -53,9 +60,9 @@ export type HotspotDetails = Hotspot & {
 };
 
 export const getHotspotMarker = ({ status }: Partial<Hotspot>) => {
-  if (status === HotspotStatus.done) return doneMarker;
-  if (status === HotspotStatus.inProgress) return inProgressMarker;
-  return todoMarker;
+  if (status === HotspotStatus.done) return doneMarkerImage;
+  if (status === HotspotStatus.inProgress) return inProgressMarkerImage;
+  return todoMarkerImage;
 };
 
 export const castToHotspot = ({

--- a/models/Hotspot.ts
+++ b/models/Hotspot.ts
@@ -6,11 +6,17 @@ import { isWeb } from '../utils/platform';
 import { castToCat, Cat } from './Cat';
 import { castToUser, User } from './User';
 
-const doneMarkerImage = isWeb() ? '/assets/assets/marker-done.png' : doneMarker;
-const inProgressMarkerImage = isWeb()
-  ? '/assets/assets/marker-in-progress.png'
-  : inProgressMarker;
-const todoMarkerImage = isWeb() ? '/assets/assets/marker-todo.png' : todoMarker;
+const markers = isWeb()
+  ? {
+      doneMarkerImage: '/assets/assets/marker-done.png',
+      inProgressMarkerImage: '/assets/assets/marker-in-progress.png',
+      todoMarkerImage: '/assets/assets/marker-todo.png',
+    }
+  : {
+      doneMarkerImage: doneMarker,
+      inProgressMarkerImage: inProgressMarker,
+      todoMarkerImage: todoMarker,
+    };
 
 export enum HotspotStatus {
   toDo = 'în așteptare',
@@ -62,11 +68,11 @@ export type HotspotDetails = Hotspot & {
 export const getHotspotMarker = ({ status }: Partial<Hotspot>) => {
   switch (status) {
     case HotspotStatus.done:
-      return doneMarkerImage;
+      return markers.doneMarkerImage;
     case HotspotStatus.inProgress:
-      return inProgressMarkerImage;
+      return markers.inProgressMarkerImage;
     default:
-      return todoMarkerImage;
+      return markers.todoMarkerImage;
   }
 };
 

--- a/models/Hotspot.ts
+++ b/models/Hotspot.ts
@@ -60,9 +60,14 @@ export type HotspotDetails = Hotspot & {
 };
 
 export const getHotspotMarker = ({ status }: Partial<Hotspot>) => {
-  if (status === HotspotStatus.done) return doneMarkerImage;
-  if (status === HotspotStatus.inProgress) return inProgressMarkerImage;
-  return todoMarkerImage;
+  switch (status) {
+    case HotspotStatus.done:
+      return doneMarkerImage;
+    case HotspotStatus.inProgress:
+      return inProgressMarkerImage;
+    default:
+      return todoMarkerImage;
+  }
 };
 
 export const castToHotspot = ({

--- a/screens/MapScreen.tsx
+++ b/screens/MapScreen.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react';
-import { Image, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import MapView, { Details } from 'react-native-maps';
 import { Caption, FAB, Title } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,12 +7,12 @@ import { useNavigation } from '@react-navigation/native';
 import currentLocationIcon from '../assets/current-location.png';
 import { Appbar } from '../components/Appbar';
 import { FullScreenActivityIndicator } from '../components/FullScreenActivityIndicator';
+import { Marker } from '../components/Marker';
 import { SearchableLocationDropdown } from '../components/SearchableLocationDropdown';
 import { initialLatitude, initialLongitude } from '../constants/location';
 import { MapContext } from '../context';
 import { findCurrentLocation } from '../context/MapContext';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
-import { Marker } from '../maps';
 import { getHotspotMarker, Hotspot } from '../models/Hotspot';
 import { EdgeInsets, Region } from '../types';
 import SnackbarManager from '../utils/SnackbarManager';
@@ -30,6 +30,7 @@ export const MapScreen = () => {
   const mapRef = useRef<MapView>(null);
   const navigation = useNavigation();
   const [isLoading, setIsLoading] = useState(false);
+  const [isMapReady, setIsMapReady] = useState(false);
   const insets = useSafeAreaInsets();
   const theme = useTheme();
   const styles = getStyles(theme, insets);
@@ -76,6 +77,7 @@ export const MapScreen = () => {
           showsUserLocation
           showsMyLocationButton={false}
           onRegionChangeComplete={onRegionChange}
+          onMapReady={() => setIsMapReady(true)}
           style={styles.map}
         >
           {hotspots.map((h: Hotspot) => (
@@ -85,16 +87,15 @@ export const MapScreen = () => {
                 latitude: h.latitude,
                 longitude: h.longitude,
               }}
+              passthroughKey={h.id}
+              height={styles.marker.height}
+              width={styles.marker.width}
+              isMapReady={isMapReady}
+              imageSource={getHotspotMarker(h)}
               onPress={() =>
                 navigation.navigate('HotspotDetail', { hotspotId: h.id })
               }
-            >
-              <Image
-                source={getHotspotMarker(h)}
-                style={styles.marker}
-                resizeMode="contain"
-              />
-            </Marker>
+            />
           ))}
         </MapView>
         <View style={styles.searchInput}>

--- a/utils/platform.ts
+++ b/utils/platform.ts
@@ -1,0 +1,3 @@
+import { Platform } from 'react-native';
+
+export const isWeb = () => Platform.OS === 'web';


### PR DESCRIPTION
As expected, the issue was the relative path used to refer to the images supposed to be displayed as marker pins. The web platform creates yet another "assets/" directory where the project's "assets" directory is copied, hence why the app did not display the paw markers.

Additionally, we have a separate Marker component which is a bit more convenient.

## Changes

- relative path replaced with `assets/assets/...` (the web platform creates yet another `assets/` directory) &rarr; cat paw markers are now displayed on web
- the `Marker` component is slightly more customizable and considers potential performance issues (`onMapReady`)


https://github.com/crafting-software/nuca-mobile/assets/32801760/803736b0-8384-47fe-947c-1706d620836d
