### PR TITLE
FIX: Validating HotspotForm and AddCatCard inputs

### DIFF
--- a/components/AddCatCard.tsx
+++ b/components/AddCatCard.tsx
@@ -25,6 +25,10 @@ import {
 import SelectDropdown from 'react-native-select-dropdown';
 import imagePlaceholder from '../assets/image-placeholder.png';
 import { isDevelopment, server } from '../config';
+import {
+  allowedNumberOfCharactersOverLimit,
+  maximumAddCatCardDescriptionLength,
+} from '../constants/inputLimits';
 import { HotspotContext } from '../context/HotspotDetailContext';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
 import { Cat, defaultSterilizedCat } from '../models/Cat';
@@ -250,6 +254,8 @@ export const AddCatCard = ({
   const [localCat, setCat] = useState<Cat>(cat || defaultSterilizedCat);
   const { hotspotDetails, setHotspotDetails } = useContext(HotspotContext);
   const [checked, setChecked] = React.useState(false);
+  const [numberOfInvalidInputsInForm, setNumberOfInvalidInputsInForm] =
+    useState(0);
   // const [images, setImages] = useState<ImagePicker.ImagePickerAsset[]>([]);
 
   useEffect(() => {
@@ -434,6 +440,25 @@ export const AddCatCard = ({
               notes: text,
             }));
           }}
+          maximumLength={
+            maximumAddCatCardDescriptionLength +
+            allowedNumberOfCharactersOverLimit
+          }
+          onTextInputValidateText={(text: string) =>
+            text.length <= maximumAddCatCardDescriptionLength
+          }
+          invalidValueErrorMessage={`Descrierea trebuie să nu depășească ${maximumAddCatCardDescriptionLength} de caractere.`}
+          infoMessage={`Maxim ${maximumAddCatCardDescriptionLength} de caractere`}
+          onInvalidInput={() =>
+            setNumberOfInvalidInputsInForm(numberOfInvalidInputsInForm + 1)
+          }
+          onValidInput={() =>
+            setNumberOfInvalidInputsInForm(
+              numberOfInvalidInputsInForm > 0
+                ? numberOfInvalidInputsInForm - 1
+                : 0
+            )
+          }
         />
         {(localCat.isSterilized || checked) && (
           <>

--- a/components/InputField.tsx
+++ b/components/InputField.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import {
   KeyboardTypeOptions,
   ReturnKeyTypeOptions,
@@ -9,7 +10,6 @@ import {
 } from 'react-native';
 import { Caption, HelperText, TextInput } from 'react-native-paper';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
-import { useEffect, useState } from 'react';
 
 export type InputFieldProps = {
   label?: string;
@@ -28,13 +28,17 @@ export type InputFieldProps = {
   onInvalidInput?: () => void;
   onValidInput?: () => void;
   invalidValueErrorMessage?: string;
+  infoMessage?: string;
   initiallyValid?: boolean;
+  maximumLength: number;
   value?: string | undefined;
 };
 
 export const InputField = (props: InputFieldProps) => {
   const theme = useTheme();
-  const [isValid, setIsValid] = useState<boolean>(props?.initiallyValid || true);
+  const [isValid, setIsValid] = useState<boolean>(
+    props?.initiallyValid || true
+  );
   const styles = StyleSheet.create({
     title: {
       color: theme.colors.text,
@@ -53,20 +57,21 @@ export const InputField = (props: InputFieldProps) => {
 
   useEffect(() => {
     if (isValid) {
-      props.onValidInput && props.onValidInput()
+      props.onValidInput && props.onValidInput();
       return;
     }
 
-    props.onInvalidInput && props.onInvalidInput()
+    props.onInvalidInput && props.onInvalidInput();
   }, [isValid]);
 
   const onChangeText = (text: string) => {
     props.onTextInputChangeText && props.onTextInputChangeText(text);
-    props.onTextInputValidateText && setIsValid(props.onTextInputValidateText(text));
-  }
+    props.onTextInputValidateText &&
+      setIsValid(props.onTextInputValidateText(text));
+  };
 
-  const getOutlineColor = () => !isValid ? 'red' : theme.colors.disabled;
-  const getActiveOutlineColor = () => !isValid ? 'red' : 'green';
+  const getOutlineColor = () => (!isValid ? 'red' : theme.colors.disabled);
+  const getActiveOutlineColor = () => (!isValid ? 'red' : 'green');
 
   return (
     <View style={props.inputFieldStyle}>
@@ -92,14 +97,15 @@ export const InputField = (props: InputFieldProps) => {
         keyboardType={props.keyboardType}
         onChangeText={onChangeText}
         value={props.value}
+        maxLength={props.maximumLength}
       />
-      {
-        !isValid && (
-          <HelperText type="error">
-            {props.invalidValueErrorMessage}
-          </HelperText>
+      {!isValid ? (
+        <HelperText type="error">{props.invalidValueErrorMessage}</HelperText>
+      ) : (
+        props?.infoMessage && (
+          <HelperText type="info">{props.infoMessage}</HelperText>
         )
-      }
+      )}
     </View>
   );
 };

--- a/components/InputField.tsx
+++ b/components/InputField.tsx
@@ -70,8 +70,10 @@ export const InputField = (props: InputFieldProps) => {
       setIsValid(props.onTextInputValidateText(text));
   };
 
-  const getOutlineColor = () => (!isValid ? 'red' : theme.colors.disabled);
-  const getActiveOutlineColor = () => (!isValid ? 'red' : 'green');
+  const getOutlineColor = () =>
+    !isValid ? theme.colors.error : theme.colors.disabled;
+  const getActiveOutlineColor = () =>
+    !isValid ? theme.colors.error : theme.colors.success;
 
   return (
     <View style={props.inputFieldStyle}>

--- a/constants/inputLimits.ts
+++ b/constants/inputLimits.ts
@@ -1,0 +1,6 @@
+export const allowedNumberOfCharactersOverLimit = 15;
+export const maximumAddressDetailsLength = 255;
+export const maximumNotesLength = 500;
+export const maximumKeyContactIndividualNameLength = 255;
+export const maximumPhoneNumberInputLength = 20;
+export const maximumAddCatCardDescriptionLength = 500;

--- a/screens/HotspotFormScreen.tsx
+++ b/screens/HotspotFormScreen.tsx
@@ -673,7 +673,7 @@ const AddLocation = ({
       <InputField
         placeholder="Adresă"
         multiline={true}
-        maximumLength={255}
+        maximumLength={maximumAddressDetailsLength}
         inputFieldStyle={{ marginTop: 30 }}
         value={location && getFormattedAddress(location)}
         editable={false}

--- a/screens/HotspotFormScreen.tsx
+++ b/screens/HotspotFormScreen.tsx
@@ -257,7 +257,8 @@ export const HotspotFormScreen = ({
 }: RootStackScreenProps<'AddHotspot'>) => {
   const { hotspots, setHotspots } = useContext(MapContext);
   const [isInProgress, setIsInProgress] = useState(false);
-  const [isFormValid, setIsFormValid] = useState(true);
+  const [numberOfInvalidInputsInForm, setNumberOfInvalidInputsInForm] =
+    useState(0);
   const [isConfirmationModalVisible, setConfirmationModalVisibility] =
     useState(false);
   const navigation =
@@ -348,7 +349,7 @@ export const HotspotFormScreen = ({
   });
 
   const saveAndNavigateToDetailScreen = async () => {
-    if (!isFormValid) {
+    if (numberOfInvalidInputsInForm) {
       isConfirmationModalVisible && dismissConfirmationModal();
       SnackbarManager.error(
         'HotspotFormScreen - save func.',
@@ -406,10 +407,22 @@ export const HotspotFormScreen = ({
                     description: text,
                   })
                 }
+                maximumLength={255 + 15}
                 onTextInputValidateText={(text: string) => text.length < 255}
-                invalidValueErrorMessage='Detaliile adresei trebuie să nu depășească 255 de caractere.'
-                onInvalidInput={() => setIsFormValid(false)}
-                onValidInput={() => setIsFormValid(true)}
+                invalidValueErrorMessage="Detaliile adresei trebuie să nu depășească 255 de caractere."
+                infoMessage="Maxim 255 de caractere"
+                onInvalidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm + 1
+                  )
+                }
+                onValidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm > 0
+                      ? numberOfInvalidInputsInForm - 1
+                      : 0
+                  )
+                }
               />
               <Caption style={styles.textInputTitle}>STATUS</Caption>
               <SelectDropdown
@@ -453,6 +466,22 @@ export const HotspotFormScreen = ({
                     notes: text,
                   })
                 }
+                maximumLength={500 + 15}
+                onTextInputValidateText={(text: string) => text.length <= 500}
+                invalidValueErrorMessage="Observațiile trebuie să nu depășească 500 de caractere."
+                infoMessage="Maxim 500 de caractere"
+                onInvalidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm + 1
+                  )
+                }
+                onValidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm > 0
+                      ? numberOfInvalidInputsInForm - 1
+                      : 0
+                  )
+                }
               />
               <InputField
                 label="Persoana de contact"
@@ -464,6 +493,21 @@ export const HotspotFormScreen = ({
                     ...temporaryHotspotDetails,
                     contactName: text,
                   })
+                }
+                maximumLength={255 + 15}
+                onTextInputValidateText={(text: string) => text.length <= 255}
+                invalidValueErrorMessage="Numele persoanei de contact trebuie să nu depășească 255 de caractere."
+                onInvalidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm + 1
+                  )
+                }
+                onValidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm > 0
+                      ? numberOfInvalidInputsInForm - 1
+                      : 0
+                  )
                 }
               />
               <InputField
@@ -477,6 +521,26 @@ export const HotspotFormScreen = ({
                     ...temporaryHotspotDetails,
                     contactPhone: text,
                   })
+                }
+                maximumLength={20}
+                onTextInputValidateText={(text: string) =>
+                  text.length < 20 &&
+                  /^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im.test(
+                    text
+                  )
+                }
+                invalidValueErrorMessage="Numǎrul de telefon al persoanei de contact trebuie sǎ fie valid."
+                onInvalidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm + 1
+                  )
+                }
+                onValidInput={() =>
+                  setNumberOfInvalidInputsInForm(
+                    numberOfInvalidInputsInForm > 0
+                      ? numberOfInvalidInputsInForm - 1
+                      : 0
+                  )
                 }
               />
               <Caption style={styles.textInputTitle}>VOLUNTAR</Caption>
@@ -588,6 +652,7 @@ const AddLocation = ({
       <InputField
         placeholder="Adresă"
         multiline={true}
+        maximumLength={255}
         inputFieldStyle={{ marginTop: 30 }}
         value={location && getFormattedAddress(location)}
         editable={false}

--- a/screens/HotspotFormScreen.tsx
+++ b/screens/HotspotFormScreen.tsx
@@ -25,6 +25,13 @@ import { FooterScreens, FooterView } from '../components/Footer';
 import { FullScreenActivityIndicator } from '../components/FullScreenActivityIndicator';
 import { InputField } from '../components/InputField';
 import { NucaModal } from '../components/NucaModal';
+import {
+  allowedNumberOfCharactersOverLimit,
+  maximumAddressDetailsLength,
+  maximumKeyContactIndividualNameLength,
+  maximumNotesLength,
+  maximumPhoneNumberInputLength,
+} from '../constants/inputLimits';
 import { findCurrentLocation, MapContext } from '../context';
 import { HotspotContext } from '../context/HotspotDetailContext';
 import { useHotspotSave } from '../hooks/useHotspotSave';
@@ -407,10 +414,15 @@ export const HotspotFormScreen = ({
                     description: text,
                   })
                 }
-                maximumLength={255 + 15}
-                onTextInputValidateText={(text: string) => text.length < 255}
-                invalidValueErrorMessage="Detaliile adresei trebuie să nu depășească 255 de caractere."
-                infoMessage="Maxim 255 de caractere"
+                maximumLength={
+                  maximumAddressDetailsLength +
+                  allowedNumberOfCharactersOverLimit
+                }
+                onTextInputValidateText={(text: string) =>
+                  text.length <= maximumAddressDetailsLength
+                }
+                invalidValueErrorMessage={`Detaliile adresei trebuie să nu depășească ${maximumAddressDetailsLength} de caractere.`}
+                infoMessage={`Maxim ${maximumAddressDetailsLength} de caractere`}
                 onInvalidInput={() =>
                   setNumberOfInvalidInputsInForm(
                     numberOfInvalidInputsInForm + 1
@@ -466,10 +478,14 @@ export const HotspotFormScreen = ({
                     notes: text,
                   })
                 }
-                maximumLength={500 + 15}
-                onTextInputValidateText={(text: string) => text.length <= 500}
-                invalidValueErrorMessage="Observațiile trebuie să nu depășească 500 de caractere."
-                infoMessage="Maxim 500 de caractere"
+                maximumLength={
+                  maximumNotesLength + allowedNumberOfCharactersOverLimit
+                }
+                onTextInputValidateText={(text: string) =>
+                  text.length <= maximumNotesLength
+                }
+                invalidValueErrorMessage={`Observațiile trebuie să nu depășească ${maximumNotesLength} de caractere.`}
+                infoMessage={`Maxim ${maximumNotesLength} de caractere`}
                 onInvalidInput={() =>
                   setNumberOfInvalidInputsInForm(
                     numberOfInvalidInputsInForm + 1
@@ -494,9 +510,14 @@ export const HotspotFormScreen = ({
                     contactName: text,
                   })
                 }
-                maximumLength={255 + 15}
-                onTextInputValidateText={(text: string) => text.length <= 255}
-                invalidValueErrorMessage="Numele persoanei de contact trebuie să nu depășească 255 de caractere."
+                maximumLength={
+                  maximumKeyContactIndividualNameLength +
+                  allowedNumberOfCharactersOverLimit
+                }
+                onTextInputValidateText={(text: string) =>
+                  text.length <= maximumKeyContactIndividualNameLength
+                }
+                invalidValueErrorMessage={`Numele persoanei de contact trebuie să nu depășească ${maximumKeyContactIndividualNameLength} de caractere.`}
                 onInvalidInput={() =>
                   setNumberOfInvalidInputsInForm(
                     numberOfInvalidInputsInForm + 1
@@ -522,9 +543,9 @@ export const HotspotFormScreen = ({
                     contactPhone: text,
                   })
                 }
-                maximumLength={20}
+                maximumLength={maximumPhoneNumberInputLength}
                 onTextInputValidateText={(text: string) =>
-                  text.length < 20 &&
+                  text.length <= maximumPhoneNumberInputLength &&
                   /^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im.test(
                     text
                   )

--- a/screens/HotspotFormScreen.tsx
+++ b/screens/HotspotFormScreen.tsx
@@ -257,6 +257,7 @@ export const HotspotFormScreen = ({
 }: RootStackScreenProps<'AddHotspot'>) => {
   const { hotspots, setHotspots } = useContext(MapContext);
   const [isInProgress, setIsInProgress] = useState(false);
+  const [isFormValid, setIsFormValid] = useState(true);
   const [isConfirmationModalVisible, setConfirmationModalVisibility] =
     useState(false);
   const navigation =
@@ -273,7 +274,7 @@ export const HotspotFormScreen = ({
   const [temporaryHotspotDetails, setTemporaryHotspotDetails] =
     useState<HotspotDetails>(hotspotDetails);
 
-  const hideConfirmationModal = () => {
+  const hideConfirmationModalAndExit = () => {
     setConfirmationModalVisibility(false);
     navigation.goBack();
   };
@@ -347,6 +348,15 @@ export const HotspotFormScreen = ({
   });
 
   const saveAndNavigateToDetailScreen = async () => {
+    if (!isFormValid) {
+      isConfirmationModalVisible && dismissConfirmationModal();
+      SnackbarManager.error(
+        'HotspotFormScreen - save func.',
+        'Formularul este încă invalid. Verifică dacă datele introduse corespund restricțiilor menționate.'
+      );
+      return;
+    }
+
     const { hotspot: newHotspot } = await save();
     !isUpdate
       ? navigation.replace('HotspotDetail', { hotspotId: newHotspot!.id })
@@ -356,7 +366,7 @@ export const HotspotFormScreen = ({
   return (
     <>
       <NucaModal
-        leftButtonHandler={hideConfirmationModal}
+        leftButtonHandler={hideConfirmationModalAndExit}
         rightButtonHandler={saveAndNavigateToDetailScreen}
         leftButtonMessage={'Renunță'}
         rightButtonMessage={'Salvează'}
@@ -396,6 +406,10 @@ export const HotspotFormScreen = ({
                     description: text,
                   })
                 }
+                onTextInputValidateText={(text: string) => text.length < 255}
+                invalidValueErrorMessage='Detaliile adresei trebuie să nu depășească 255 de caractere.'
+                onInvalidInput={() => setIsFormValid(false)}
+                onValidInput={() => setIsFormValid(true)}
               />
               <Caption style={styles.textInputTitle}>STATUS</Caption>
               <SelectDropdown
@@ -437,20 +451,6 @@ export const HotspotFormScreen = ({
                   setTemporaryHotspotDetails({
                     ...temporaryHotspotDetails,
                     notes: text,
-                  })
-                }
-              />
-              <InputField
-                label="Pisici nesterilizate"
-                placeholder="0"
-                keyboardType="number-pad"
-                value={String(
-                  temporaryHotspotDetails.unsterilizedCatsCount || 0
-                )}
-                onTextInputChangeText={text =>
-                  setTemporaryHotspotDetails({
-                    ...temporaryHotspotDetails,
-                    unsterilizedCatsCount: Number(text),
                   })
                 }
               />


### PR DESCRIPTION
## Changes:

We avoided using a validation library by simply exploiting the props of the `TextInput` component from __react-native-paper__ which allow us to modify the color of the input field's outline and add helper messages, in case the user types an invalid string (length-wise or structure-wise e.g. phone number).

- The `InputField` component has additional props used to decide how the input should be validated. If an input field is invalid, the save button on the `HotspotFormScreen` and the one in the confirmation modal are disabled &rarr; an error snackbar message is also displayed when attempting to save a form containing invalid data.
- Besides `HotspotFormScreen`, `AddCatCard` also uses the recently-modified, validated `InputField` component. The only difference is that inputs with a character count above 500 (although flagged as invalid through an error message displayed for the user) are still allowed to be saved in a CatCard as long as they are shorter than 515 characters (the 15 additional characters are left in there, so that the error message is displayed, more like a warning rather than an error which prevents saving the card. Nonetheless, as for the `InputField` instances on `HotspotFormScreen`, users are not allowed to insert more characters than the intended character limit in the input field + the "left-over" 15 characters i.e. 515.

Any suggestions? 😃 

## Demo

### AddCatCard

https://github.com/crafting-software/nuca-mobile/assets/32801760/0d59eb2c-0e37-4040-8225-098cf52e13f9

### HotspotFormScreen

https://github.com/crafting-software/nuca-mobile/assets/32801760/c0073d45-f149-4213-94d6-775e12fab7ab

