### PR TITLE
FIX: Display the confirmation modal when the Android back button is tapped

### DIFF
--- a/components/AddCatCard.tsx
+++ b/components/AddCatCard.tsx
@@ -33,7 +33,7 @@ import { Cat, defaultSterilizedCat } from '../models/Cat';
 import { User } from '../models/User';
 import SnackbarManager from '../utils/SnackbarManager';
 import { updateCat } from '../utils/cats';
-import { loadUsers } from '../utils/users';
+import { loadUsersRequest } from '../utils/users';
 import { InputField } from './InputField';
 import { NucaModal } from './NucaModal';
 
@@ -256,7 +256,7 @@ export const AddCatCard = ({
 
   useEffect(() => {
     const load = async () => {
-      const { success, users } = await loadUsers();
+      const { success, users } = await loadUsersRequest();
       if (!success) alert('Failed to load users');
       setUsers(users);
     };

--- a/utils/users.ts
+++ b/utils/users.ts
@@ -1,7 +1,7 @@
 import { castToUser, User } from '../models/User';
 import { makeRequest } from './server';
 
-export const loadUsers = async (): Promise<{
+export const loadUsersRequest = async (): Promise<{
   success: boolean;
   users: User[];
 }> => {


### PR DESCRIPTION
## Description

Before these changes, tapping on the OS back button on Android did not trigger the confirmation modal.

## Demo

https://github.com/crafting-software/nuca-mobile/assets/32801760/aa736277-1357-4935-b7bb-d84b53fd7853

