### PR TITLE
FIX: Card description containing numbers replaced with nonsensical date

### DIFF
--- a/utils/server.ts
+++ b/utils/server.ts
@@ -16,6 +16,14 @@ const getAuthorizationHeader = async () => {
   }
 };
 
+const isValueAnObject = (value: any) =>
+  value && typeof value === 'object' && !(value instanceof File);
+const isValueADate = (value: any) =>
+  moment(value, 'YYYY-MM-DD', true).isValid() ||
+  moment.utc(value, 'ddd MMM DD YYYY HH:mm:ss', true).isValid();
+const isValueAnArray = (value: any) => Array.isArray(value);
+const isValueUndefined = (value: any) => value !== undefined;
+
 const objectToFormData = (
   obj: Record<string, any>,
   formData: FormData = new FormData(),
@@ -24,27 +32,21 @@ const objectToFormData = (
   Object.entries(obj).reduce((fd: FormData, [key, value]: [string, any]) => {
     const propName: string = parentKey ? `${parentKey}[${key}]` : key;
 
-    if (
-      typeof value === 'object' &&
-      value !== null &&
-      !(value instanceof File) &&
-      !Date.parse(value)
-    ) {
-      return objectToFormData(value, fd, propName);
-    } else if (
-      Date.parse(value)
-      && typeof value == 'string'
-      && moment(value, 'YYYY-MM-DD', true).isValid()
-      || moment.utc(value, 'ddd MMM DD YYYY HH:mm:ss', true).isValid()
-    ) {
-      const formattedDate = moment(new Date(value)).format('YYYY-MM-DD');
-      fd.append(propName, formattedDate);
-    } else if (Array.isArray(value)) {
-      value.forEach((item: any, index: number) =>
-        objectToFormData(item, fd, `${propName}[${index}]`)
-      );
-    } else {
-      if (value !== undefined) fd.append(propName, value);
+    switch (true) {
+      case isValueADate(value):
+        const formattedDate = moment(new Date(value)).format('YYYY-MM-DD');
+        fd.append(propName, formattedDate);
+        break;
+      case isValueAnObject(value):
+        return objectToFormData(value, fd, propName);
+      case isValueAnArray(value):
+        value.forEach((item: any, index: number) =>
+          objectToFormData(item, fd, `${propName}[${index}]`)
+        );
+        break;
+      case isValueUndefined(value):
+        fd.append(propName, value);
+        break;
     }
 
     return fd;

--- a/utils/server.ts
+++ b/utils/server.ts
@@ -31,7 +31,12 @@ const objectToFormData = (
       !Date.parse(value)
     ) {
       return objectToFormData(value, fd, propName);
-    } else if (Date.parse(value)) {
+    } else if (
+      Date.parse(value)
+      && typeof value == 'string'
+      && moment(value, 'YYYY-MM-DD', true).isValid()
+      || moment.utc(value, 'ddd MMM DD YYYY HH:mm:ss', true).isValid()
+    ) {
       const formattedDate = moment(new Date(value)).format('YYYY-MM-DD');
       fd.append(propName, formattedDate);
     } else if (Array.isArray(value)) {


### PR DESCRIPTION
## Issue (specific to the web platform)

The `objectToFormData` used to convert an object to be sent as a request payload is applied recursively on all values (including nested objects) of an object. The `Date.parse(...)` function does not properly check whether a string is a date or not, instead it considers numbers within a string as a hint that the string is a date and interprets these numbers as months e.g. `Date.parse('test 2')` is translated to `Thu Feb 01 2001 00:00:00 GMT+0200 (Eastern European Standard Time)`. 

This issue is trivial, but important [(no one would want a string to be randomly converted to a date)](https://stackoverflow.com/questions/59103771/new-date-producing-valid-date-from-invalid-input-string).

## Changes 

- `Date.parse(...)` is replaced with a strict check of the date format found in the app (using Moment.js).
- chained `if` statement is replaced with a `switch` statement

## Demo 

### Before:

https://github.com/crafting-software/nuca-mobile/assets/32801760/113ae990-d8cd-4cc2-b042-cbb5bd6b98f9

### After:

https://github.com/crafting-software/nuca-mobile/assets/32801760/fef7fb46-a000-4f29-b069-e2dacf787be6
