### PR TITLE
FIX: Remove unnecessary shadow offset on modal pop-ups

### DIFF
--- a/components/AddCatCard.tsx
+++ b/components/AddCatCard.tsx
@@ -15,8 +15,6 @@ import {
   Checkbox,
   Icon,
   IconButton,
-  Modal,
-  Portal,
   TextInput,
 } from 'react-native-paper';
 import {
@@ -351,19 +349,17 @@ export const AddCatCard = ({
 
   return (
     <Card style={styles.mainContainer}>
-      <Portal>
-        <Modal visible={visible} onDismiss={hideModal}>
-          <NucaModal
-            leftButtonHandler={hideModal}
-            rightButtonHandler={deleteCatCallback}
-            leftButtonMessage={'Renunță'}
-            rightButtonMessage={'Șterge'}
-            leftButtonIcon={'cancel'}
-            rightButtonIcon={'close'}
-            caption={'Ești sigur că vrei să ștergi?'}
-          />
-        </Modal>
-      </Portal>
+      <NucaModal
+        leftButtonHandler={hideModal}
+        rightButtonHandler={deleteCatCallback}
+        leftButtonMessage={'Renunță'}
+        rightButtonMessage={'Șterge'}
+        leftButtonIcon={'cancel'}
+        rightButtonIcon={'close'}
+        caption={'Ești sigur că vrei să ștergi?'}
+        visible={visible}
+        onDismiss={hideModal}
+      />
       <View style={styles.container}>
         <View style={styles.titleRow}>
           {isEditingMode ? (

--- a/components/CatCard.tsx
+++ b/components/CatCard.tsx
@@ -1,14 +1,7 @@
 import { isEmpty } from 'lodash';
 import { useState } from 'react';
 import { FlatList, Image, StyleSheet, View } from 'react-native';
-import {
-  Button,
-  Caption,
-  Card,
-  IconButton,
-  Modal,
-  Portal,
-} from 'react-native-paper';
+import { Button, Caption, Card, IconButton } from 'react-native-paper';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
 import { Cat, getDateText } from '../models/Cat';
 import { AddCatCard } from './AddCatCard';
@@ -22,6 +15,17 @@ const getStyles = (theme: NucaCustomTheme) =>
       backgroundColor: theme.colors.surface,
       borderRadius: 30,
       marginBottom: 10,
+    },
+    modalWrapperStyle: {
+      width: '100%',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    modalWrapperContainerStyle: {
+      shadowOffset: {
+        width: 0,
+        height: 0,
+      },
     },
     container: {
       padding: 20,
@@ -165,19 +169,17 @@ export const CatCard = ({
     <>
       {!shouldEdit ? (
         <Card style={styles.mainContainer}>
-          <Portal>
-            <Modal visible={visible} onDismiss={hideModal}>
-              <NucaModal
-                leftButtonHandler={hideModal}
-                rightButtonHandler={deleteCatCallback}
-                leftButtonMessage={'Renunță'}
-                rightButtonMessage={'Șterge'}
-                leftButtonIcon={'cancel'}
-                rightButtonIcon={'close'}
-                caption={'Ești sigur că vrei să ștergi?'}
-              />
-            </Modal>
-          </Portal>
+          <NucaModal
+            leftButtonHandler={hideModal}
+            rightButtonHandler={deleteCatCallback}
+            leftButtonMessage={'Renunță'}
+            rightButtonMessage={'Șterge'}
+            leftButtonIcon={'cancel'}
+            rightButtonIcon={'close'}
+            caption={'Ești sigur că vrei să ștergi?'}
+            visible={visible}
+            onDismiss={hideModal}
+          />
           <View style={styles.container}>
             <View style={styles.titleRow}>
               <Caption style={styles.index}>{index}.</Caption>

--- a/components/NucaModal.tsx
+++ b/components/NucaModal.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, View } from 'react-native';
-import { Button, Caption, Card } from 'react-native-paper';
+import { Button, Caption, Card, Modal, Portal } from 'react-native-paper';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
 
 const getModalStyles = (theme: NucaCustomTheme) =>
@@ -12,6 +12,17 @@ const getModalStyles = (theme: NucaCustomTheme) =>
       lineHeight: 22,
       fontFamily: 'Nunito_700Bold',
       paddingLeft: 8,
+    },
+    modalWrapperStyle: {
+      width: '100%',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    modalWrapperContainerStyle: {
+      shadowOffset: {
+        width: 0,
+        height: 0,
+      },
     },
     discardButton: {
       height: 66,
@@ -69,6 +80,8 @@ export const NucaModal = ({
   leftButtonIcon,
   rightButtonIcon,
   caption,
+  visible,
+  onDismiss,
 }: {
   leftButtonHandler: () => void;
   rightButtonHandler: () => void;
@@ -77,39 +90,50 @@ export const NucaModal = ({
   leftButtonIcon: string;
   rightButtonIcon: string;
   caption: string;
+  visible: boolean;
+  onDismiss: () => void;
 }) => {
   const theme = useTheme();
   const styles = getModalStyles(theme);
 
   return (
-    <View style={styles.mainContainer}>
-      <Card style={styles.cardStyle}>
-        <Caption style={styles.title}>{caption}</Caption>
-        <View style={styles.actionView}>
-          <View style={styles.buttonView}>
-            <Button
-              style={styles.discardButton}
-              contentStyle={styles.buttonContent}
-              labelStyle={styles.buttonLabel}
-              icon={leftButtonIcon}
-              onPress={leftButtonHandler}
-            >
-              {leftButtonMessage}
-            </Button>
-          </View>
-          <View style={styles.buttonView}>
-            <Button
-              style={styles.deleteButton}
-              contentStyle={styles.buttonContent}
-              labelStyle={styles.buttonLabel}
-              icon={rightButtonIcon}
-              onPress={rightButtonHandler}
-            >
-              {rightButtonMessage}
-            </Button>
-          </View>
+    <Portal>
+      <Modal
+        visible={visible}
+        onDismiss={onDismiss}
+        style={styles.modalWrapperStyle}
+        contentContainerStyle={styles.modalWrapperContainerStyle}
+      >
+        <View style={styles.mainContainer}>
+          <Card style={styles.cardStyle}>
+            <Caption style={styles.title}>{caption}</Caption>
+            <View style={styles.actionView}>
+              <View style={styles.buttonView}>
+                <Button
+                  style={styles.discardButton}
+                  contentStyle={styles.buttonContent}
+                  labelStyle={styles.buttonLabel}
+                  icon={leftButtonIcon}
+                  onPress={leftButtonHandler}
+                >
+                  {leftButtonMessage}
+                </Button>
+              </View>
+              <View style={styles.buttonView}>
+                <Button
+                  style={styles.deleteButton}
+                  contentStyle={styles.buttonContent}
+                  labelStyle={styles.buttonLabel}
+                  icon={rightButtonIcon}
+                  onPress={rightButtonHandler}
+                >
+                  {rightButtonMessage}
+                </Button>
+              </View>
+            </View>
+          </Card>
         </View>
-      </Card>
-    </View>
+      </Modal>
+    </Portal>
   );
 };

--- a/screens/HotspotFormScreen.tsx
+++ b/screens/HotspotFormScreen.tsx
@@ -12,8 +12,6 @@ import {
   Button,
   Caption,
   Headline,
-  Modal,
-  Portal,
   TextInput,
   Title,
 } from 'react-native-paper';
@@ -51,6 +49,17 @@ const getStyles = (theme: NucaCustomTheme) =>
     container: {
       backgroundColor: theme.colors.background,
       flex: 1,
+    },
+    modalWrapperStyle: {
+      width: '100%',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    modalWrapperContainerStyle: {
+      shadowOffset: {
+        width: 0,
+        height: 0,
+      },
     },
     form: {
       padding: 20,
@@ -346,24 +355,19 @@ export const HotspotFormScreen = ({
 
   return (
     <>
-      <Portal>
-        <Modal
-          visible={isConfirmationModalVisible}
-          onDismiss={dismissConfirmationModal}
-        >
-          <NucaModal
-            leftButtonHandler={hideConfirmationModal}
-            rightButtonHandler={saveAndNavigateToDetailScreen}
-            leftButtonMessage={'Renunță'}
-            rightButtonMessage={'Salvează'}
-            leftButtonIcon={'cancel'}
-            rightButtonIcon={'pencil'}
-            caption={
-              'Ești sigur că vrei să ieși? Modificările tale nu vor fi salvate.'
-            }
-          />
-        </Modal>
-      </Portal>
+      <NucaModal
+        leftButtonHandler={hideConfirmationModal}
+        rightButtonHandler={saveAndNavigateToDetailScreen}
+        leftButtonMessage={'Renunță'}
+        rightButtonMessage={'Salvează'}
+        leftButtonIcon={'cancel'}
+        rightButtonIcon={'pencil'}
+        caption={
+          'Ești sigur că vrei să ieși? Modificările tale nu vor fi salvate.'
+        }
+        visible={isConfirmationModalVisible}
+        onDismiss={dismissConfirmationModal}
+      />
       <Appbar forDetailScreen showConfirmationModal={showConfirmationModal} />
       <View style={styles.container}>
         <ScrollView>


### PR DESCRIPTION
## Changes

To remove the horizontal line displayed behind the modal on web, the shadow offset on the content container of the react-native-paper `Modal` had to be set to 0 (both the width and the height).

### Before:

<img width="1789" alt="modal-before" src="https://github.com/crafting-software/nuca-mobile/assets/32801760/ccc60673-c142-4a26-91e8-a3490c88158d">

### After:

<img width="1792" alt="modal-fixed" src="https://github.com/crafting-software/nuca-mobile/assets/32801760/28a1bc8a-d9f0-4080-ab94-bd476e025c82">
