### PR TITLE
FIX: Update the visible cat counter state when cat cards are added or deleted

### DIFF
--- a/screens/HotspotDetailScreen.tsx
+++ b/screens/HotspotDetailScreen.tsx
@@ -606,13 +606,21 @@ export const CatsView = ({
 }) => {
   const theme = useTheme();
   const styles = getStyles(theme);
-  const maxVisibleCat = 2;
-  const [visibleCat, setVisible] = useState<number>(maxVisibleCat);
+  const initialNumberOfVisibleCats = 2;
+  const [numberOfVisibleCats, setNumberOfVisibleCats] = useState<number>(
+    initialNumberOfVisibleCats
+  );
+
+  useEffect(() => {
+    if (numberOfVisibleCats <= 2) return;
+
+    setNumberOfVisibleCats(cats.length);
+  }, [cats]);
 
   return isSmallScreen() ? (
     <View>
       {cats
-        .slice(0, visibleCat)
+        .slice(0, numberOfVisibleCats)
         .map((cat, index) =>
           cat.isNew ? (
             <AddCatCard
@@ -631,20 +639,21 @@ export const CatsView = ({
             />
           )
         )}
-      {cats.length > maxVisibleCat && visibleCat === maxVisibleCat && (
-        <View style={{ alignItems: 'center' }}>
-          <Button
-            style={styles.moreButton}
-            contentStyle={styles.moreButtonContent}
-            labelStyle={styles.moreButtonLabel}
-            icon="arrow-down"
-            mode="contained"
-            onPress={() => setVisible(cats.length)}
-          >
-            vezi mai multe
-          </Button>
-        </View>
-      )}
+      {cats.length > initialNumberOfVisibleCats &&
+        numberOfVisibleCats === initialNumberOfVisibleCats && (
+          <View style={{ alignItems: 'center' }}>
+            <Button
+              style={styles.moreButton}
+              contentStyle={styles.moreButtonContent}
+              labelStyle={styles.moreButtonLabel}
+              icon="arrow-down"
+              mode="contained"
+              onPress={() => setNumberOfVisibleCats(cats.length)}
+            >
+              vezi mai multe
+            </Button>
+          </View>
+        )}
     </View>
   ) : (
     <View style={styles.catsWebViewContainer}>


### PR DESCRIPTION
## Changes:

The number of visible cats in the list is now adjusted whenever a card is added or removed, thereby solving the issue of older cards disappearing when a new card is added in an expanded list.

## Demo

### Before:

https://github.com/crafting-software/nuca-mobile/assets/32801760/f9cd0bfb-c403-4a17-9c07-c02256b9a416

### After:

https://github.com/crafting-software/nuca-mobile/assets/32801760/255e36a4-7d74-48a9-942f-b5a1eda276fc

