### PR TITLE
FIX: Hotspot creation confirmation button contains a white circle overlapping the button label

### DIFF
--- a/screens/ChooseLocationScreen.tsx
+++ b/screens/ChooseLocationScreen.tsx
@@ -177,15 +177,19 @@ export const ChooseLocationScreen = ({
             });
           }}
         >
-          <Caption style={styles.confirmAddressButtonLabel}>
-            CONFIRMĂ ADRESA
-          </Caption>
-          <View style={styles.confirmAddressButtonIconContainer}>
-            <TextInput.Icon
-              size={20}
-              icon={'check'}
-              color={theme.colors.background}
-            />
+          <View style={styles.confirmAddressButtonLabelContainer}>
+            <Caption style={styles.confirmAddressButtonLabel}>
+              CONFIRMĂ ADRESA
+            </Caption>
+            <View style={styles.confirmAddressButtonIconContainer}>
+              <TextInput.Icon
+                size={20}
+                icon={'check'}
+                color={theme.colors.success}
+                style={styles.confirmAddressButtonIcon}
+                disabled
+              />
+            </View>
           </View>
         </TouchableOpacity>
       ) : null}
@@ -221,7 +225,6 @@ const getStyles = (theme: NucaCustomTheme, insets: EdgeInsets) =>
       backgroundColor: theme.colors.text,
     },
     confirmAddressButton: {
-      flexDirection: 'row',
       position: 'absolute',
       bottom: Math.max(20, insets.bottom as number),
       left: 20,
@@ -243,11 +246,20 @@ const getStyles = (theme: NucaCustomTheme, insets: EdgeInsets) =>
       fontFamily: 'Nunito_700Bold',
       letterSpacing: 0.2,
     },
+    confirmAddressButtonLabelContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
     confirmAddressButtonIconContainer: {
       width: 20,
       alignItems: 'center',
       height: 20,
       marginBottom: 10,
+      marginLeft: 8,
+    },
+    confirmAddressButtonIcon: {
+      backgroundColor: theme.colors.text,
+      opacity: 100,
     },
     searchInput: {
       position: 'absolute',


### PR DESCRIPTION
## Changes

- the pressable checkmark icon on the location confirmation button is now disabled
- the white circle background issue on web is now fixed

The changes are supposed to use a similar style for the hotspot creation confirmation button like the button on `MapScreen`, to fix the issue of the clickable icon and the white circle on web.

## Demo

### Before:

https://github.com/crafting-software/nuca-mobile/assets/32801760/0db5f519-d515-4a4a-ba51-bbb5892c0644

### After:

https://github.com/crafting-software/nuca-mobile/assets/32801760/4c8aa29a-f338-4cca-877a-914c7defacd0
