### PR TITLE
FIX: The volunteer name in the cat cards might exceed the boundary of the component

### DIFF
--- a/components/CatCard.tsx
+++ b/components/CatCard.tsx
@@ -75,6 +75,7 @@ const getStyles = (theme: NucaCustomTheme) =>
       fontSize: 15,
       fontFamily: 'Nunito_400Regular',
       flexWrap: 'wrap',
+      flexShrink: 1,
     },
     iconAndText: {
       width: '50%',


### PR DESCRIPTION
## Changes

- the wrapped volunteer name is shrinked when the volunteer name is long

## Demo

### iOS

#### Before:

<img width="413" alt="ios-before" src="https://github.com/crafting-software/nuca-mobile/assets/32801760/b9f975a9-57c6-4c47-a1b1-dd9a1bfca71d">

#### After:

<img width="411" alt="ios-after" src="https://github.com/crafting-software/nuca-mobile/assets/32801760/1c424acf-8b30-4283-b002-7f73d07f0122">

### Android

#### Before:

<img width="369" alt="android-before" src="https://github.com/crafting-software/nuca-mobile/assets/32801760/f3794787-0ed5-4c62-aa18-65800c36d6d2">

#### After:

<img width="368" alt="android-after" src="https://github.com/crafting-software/nuca-mobile/assets/32801760/ce5647c4-1070-493f-a691-046121faea7c">

