### PR TITLE
FIX: Truncated "View more" button label on devices with a smaller width

### DIFF
--- a/screens/HotspotDetailScreen.tsx
+++ b/screens/HotspotDetailScreen.tsx
@@ -191,7 +191,7 @@ const getStyles = (theme: NucaCustomTheme) =>
       height: 40,
       marginTop: 24,
       marginBottom: 24,
-      maxWidth: 150,
+      minWidth: 150,
     },
     moreButtonContent: {
       height: 40,


### PR DESCRIPTION
## Changes

The maxWidth prop was used incorrectly instead of minWidth (which makes more sense in this context). The device in question which displayed a truncated button label was Samsung A52S.

## Demo

### Before

![Screenshot_20240424_143245_Expo_Go](https://github.com/crafting-software/nuca-mobile/assets/32801760/5664a1b5-b7b6-45f6-9132-69960a6d7fc8)

### After

![Screenshot_20240520_123133_Expo Go](https://github.com/crafting-software/nuca-mobile/assets/32801760/b711e251-2038-4721-86ec-f6bdedde2d55)



