### PR TITLE
FEAT: Report generation screen

### DIFF
--- a/components/AddCatCard.tsx
+++ b/components/AddCatCard.tsx
@@ -70,14 +70,6 @@ const getStyles = (theme: NucaCustomTheme) =>
       marginRight: 8,
       marginTop: 6,
     },
-    saveButton: {
-      height: 66,
-      width: '100%',
-      backgroundColor: theme.colors.accent,
-      borderRadius: 0,
-      borderBottomLeftRadius: 30,
-      borderBottomRightRadius: 30,
-    },
     buttonContent: {
       height: 66,
       alignItems: 'center',

--- a/components/Appbar.tsx
+++ b/components/Appbar.tsx
@@ -51,13 +51,19 @@ export const Appbar = ({
       >
         <Menu.Item
           leadingIcon="file-chart-outline"
-          onPress={() => {}}
+          onPress={() => {
+            navigation.navigate('ReportGeneration');
+            setIsMenuOpen(false);
+          }}
           title="Generare raport"
         />
         <Divider />
         <Menu.Item
           leadingIcon="exit-to-app"
-          onPress={signOut}
+          onPress={() => {
+            signOut();
+            setIsMenuOpen(false);
+          }}
           title="Ieșire din cont"
         />
       </Menu>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Image, Platform, StyleSheet, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 import catLady2 from '../assets/cat-lady2.png';
 import catLady3 from '../assets/cat-lady3.png';
 import catLady3Web from '../assets/cat-lady3W.png';
@@ -13,21 +13,17 @@ const getFooterStyles = (_theme: NucaCustomTheme) =>
   StyleSheet.create({
     imageView: {
       marginTop: 32,
+      flex: 1,
     },
     image: {
+      alignSelf: 'center',
+      position: 'absolute',
+      bottom: isSmallScreen() ? '-20%' : 0,
       paddingTop: 12,
-      height: 375,
-      minHeight: 430,
+      height: 430,
+      zIndex: -1,
+      width: '100%',
       flex: 1,
-      width: undefined,
-    },
-    zoomedImage: {
-      paddingTop: 12,
-      height: 375,
-      minHeight: 430,
-      flex: 1,
-      width: undefined,
-      transform: [{ scale: 1.4 }],
     },
   });
 
@@ -67,15 +63,6 @@ export const FooterView = ({
     }
   }
 
-  function getStyle(screen: FooterScreens) {
-    switch (screen) {
-      case FooterScreens.HotspotDetailScreen:
-        return styles.image;
-      default:
-        return Platform.OS === 'web' ? styles.zoomedImage : styles.image;
-    }
-  }
-
   return (
     <View style={styles.imageView}>
       <Image
@@ -84,7 +71,7 @@ export const FooterView = ({
             ? getSmallScreenImage(screen)
             : getWideScreenImage(screen)
         }
-        style={getStyle(screen)}
+        style={styles.image}
         resizeMode={isSmallScreen() ? 'contain' : 'cover'}
       />
     </View>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,6 +4,7 @@ import catLady3 from '../assets/cat-lady3.png';
 import catLady3Web from '../assets/cat-lady3W.png';
 import catLady4 from '../assets/cat-lady4.png';
 import catLady4Web from '../assets/cat-lady4W.png';
+import catLady5 from '../assets/cat-lady5.png';
 import catLady5Web from '../assets/cat-lady5W.png';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
 import { isSmallScreen } from '../utils/helperFunc';
@@ -38,6 +39,8 @@ export const FooterView = ({
         return catLady3;
       case FooterScreens.HotspotFormScreen:
         return isUpdate ? catLady4 : catLady2;
+      case FooterScreens.ReportGenerationScreen:
+        return catLady5;
       default:
         throw new Error(`Non-existent image in switch: ${screen}`);
     }
@@ -49,6 +52,8 @@ export const FooterView = ({
         return catLady3Web;
       case FooterScreens.HotspotFormScreen:
         return isUpdate ? catLady4Web : catLady5Web;
+      case FooterScreens.ReportGenerationScreen:
+        return catLady5Web;
       default:
         throw new Error(`Non-existent image in switch: ${screen}`);
     }
@@ -72,4 +77,5 @@ export const FooterView = ({
 export enum FooterScreens {
   HotspotDetailScreen,
   HotspotFormScreen,
+  ReportGenerationScreen,
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,7 @@ import catLady4Web from '../assets/cat-lady4W.png';
 import catLady5 from '../assets/cat-lady5.png';
 import catLady5Web from '../assets/cat-lady5W.png';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
-import { isSmallScreen } from '../utils/helperFunc';
+import { isSmallMobileScreen } from '../utils/helperFunc';
 
 const getFooterStyles = (_theme: NucaCustomTheme) =>
   StyleSheet.create({
@@ -18,7 +18,7 @@ const getFooterStyles = (_theme: NucaCustomTheme) =>
     image: {
       alignSelf: 'center',
       position: 'absolute',
-      bottom: isSmallScreen() ? '-20%' : 0,
+      bottom: isSmallMobileScreen() ? '-20%' : 0,
       paddingTop: 12,
       height: 430,
       zIndex: -1,
@@ -67,12 +67,12 @@ export const FooterView = ({
     <View style={styles.imageView}>
       <Image
         source={
-          isSmallScreen()
+          isSmallMobileScreen()
             ? getSmallScreenImage(screen)
             : getWideScreenImage(screen)
         }
         style={styles.image}
-        resizeMode={isSmallScreen() ? 'contain' : 'cover'}
+        resizeMode={isSmallMobileScreen() ? 'contain' : 'cover'}
       />
     </View>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Image, StyleSheet, View } from 'react-native';
+import { Image, Platform, StyleSheet, View } from 'react-native';
 import catLady2 from '../assets/cat-lady2.png';
 import catLady3 from '../assets/cat-lady3.png';
 import catLady3Web from '../assets/cat-lady3W.png';
@@ -20,6 +20,14 @@ const getFooterStyles = (_theme: NucaCustomTheme) =>
       minHeight: 430,
       flex: 1,
       width: undefined,
+    },
+    zoomedImage: {
+      paddingTop: 12,
+      height: 375,
+      minHeight: 430,
+      flex: 1,
+      width: undefined,
+      transform: [{ scale: 1.4 }],
     },
   });
 
@@ -59,6 +67,15 @@ export const FooterView = ({
     }
   }
 
+  function getStyle(screen: FooterScreens) {
+    switch (screen) {
+      case FooterScreens.HotspotDetailScreen:
+        return styles.image;
+      default:
+        return Platform.OS === 'web' ? styles.zoomedImage : styles.image;
+    }
+  }
+
   return (
     <View style={styles.imageView}>
       <Image
@@ -67,7 +84,7 @@ export const FooterView = ({
             ? getSmallScreenImage(screen)
             : getWideScreenImage(screen)
         }
-        style={styles.image}
+        style={getStyle(screen)}
         resizeMode={isSmallScreen() ? 'contain' : 'cover'}
       />
     </View>

--- a/components/NucaFormButton.tsx
+++ b/components/NucaFormButton.tsx
@@ -10,6 +10,7 @@ const getStyles = () =>
       minWidth: isSmallScreen() ? 64 : 340,
       marginBottom: 10,
       marginRight: isSmallScreen() ? 0 : 12,
+      zIndex: 2,
     },
     saveButtonContent: {
       height: 64,

--- a/components/NucaFormButton.tsx
+++ b/components/NucaFormButton.tsx
@@ -1,0 +1,63 @@
+import { StyleSheet } from 'react-native';
+import { Button } from 'react-native-paper';
+import { isSmallScreen } from '../utils/helperFunc';
+
+const getStyles = () =>
+  StyleSheet.create({
+    saveButton: {
+      height: 64,
+      maxWidth: 340,
+      minWidth: isSmallScreen() ? 64 : 340,
+      marginBottom: 10,
+      marginRight: isSmallScreen() ? 0 : 12,
+    },
+    saveButtonContent: {
+      height: 64,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'row-reverse',
+    },
+    buttonLabel: {
+      fontSize: 18,
+      marginStart: 8,
+      textAlignVertical: 'bottom',
+      fontFamily: 'Nunito_700Bold',
+    },
+  });
+
+type NucaFormButtonProps = {
+  label: string;
+  iconName: string;
+  backgroundColor: string;
+  labelColor: string;
+  onPress: () => any;
+};
+
+export const NucaFormButton = ({
+  label,
+  backgroundColor,
+  labelColor,
+  iconName,
+  onPress,
+}: NucaFormButtonProps) => {
+  const styles = getStyles();
+  const buttonLabelStyle = { ...styles.buttonLabel, color: labelColor };
+  const buttonStyle = {
+    ...styles.saveButton,
+    backgroundColor: backgroundColor,
+  };
+
+  return (
+    <Button
+      uppercase={false}
+      style={buttonStyle}
+      contentStyle={styles.saveButtonContent}
+      labelStyle={buttonLabelStyle}
+      onPress={onPress}
+      icon={iconName}
+      mode="contained"
+    >
+      {label}
+    </Button>
+  );
+};

--- a/components/NucaFormButton.tsx
+++ b/components/NucaFormButton.tsx
@@ -31,7 +31,7 @@ type NucaFormButtonProps = {
   iconName: string;
   backgroundColor: string;
   labelColor: string;
-  onPress: () => any;
+  onPress: () => void;
 };
 
 export const NucaFormButton = ({

--- a/navigation/LinkingConfiguration.ts
+++ b/navigation/LinkingConfiguration.ts
@@ -14,6 +14,7 @@ const linking: LinkingOptions<RootStackParamList> = {
       Main: 'main',
       AddHotspot: 'addHotspot',
       HotspotDetail: 'hotspotDetail',
+      ReportGeneration: 'reportGeneration',
       NotFound: '*',
       ChooseLocation: 'chooseLocation',
     },

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -10,6 +10,7 @@ import { HotspotFormScreen } from '../screens/HotspotFormScreen';
 import { MapScreen } from '../screens/MapScreen';
 import { ModalScreen } from '../screens/ModalScreen';
 import { NotFoundScreen } from '../screens/NotFoundScreen';
+import { ReportGenerationScreen } from '../screens/ReportGenerationScreen';
 import { RootStackParamList } from '../types';
 import LinkingConfiguration from './LinkingConfiguration';
 
@@ -53,6 +54,11 @@ const RootNavigator = () => {
           <Stack.Screen
             name="HotspotDetail"
             component={HotspotDetailScreen}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="ReportGeneration"
+            component={ReportGenerationScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen

--- a/screens/HotspotFormScreen.tsx
+++ b/screens/HotspotFormScreen.tsx
@@ -8,13 +8,7 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import {
-  Button,
-  Caption,
-  Headline,
-  TextInput,
-  Title,
-} from 'react-native-paper';
+import { Caption, Headline, TextInput, Title } from 'react-native-paper';
 import SelectDropdown from 'react-native-select-dropdown';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -24,6 +18,7 @@ import { Appbar } from '../components/Appbar';
 import { FooterScreens, FooterView } from '../components/Footer';
 import { FullScreenActivityIndicator } from '../components/FullScreenActivityIndicator';
 import { InputField } from '../components/InputField';
+import { NucaFormButton } from '../components/NucaFormButton';
 import { NucaModal } from '../components/NucaModal';
 import {
   allowedNumberOfCharactersOverLimit,
@@ -167,39 +162,9 @@ const getStyles = (theme: NucaCustomTheme) =>
       margin: 1,
       right: 0,
     },
-    saveButton: {
-      height: 64,
-      maxWidth: 340,
-      minWidth: isSmallScreen() ? 64 : 340,
-    },
-    deleteButton: {
-      height: 64,
-      backgroundColor: theme.colors.surface,
-      color: 'black',
-      minWidth: isSmallScreen() ? 64 : 340,
-      maxWidth: 340,
-      marginRight: isSmallScreen() ? 0 : 12,
-      marginBottom: 10,
-    },
-    saveButtonContent: {
-      height: 64,
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexDirection: 'row-reverse',
-    },
-    saveButtonLabel: {
-      color: theme.colors.background,
-      fontSize: 18,
-      fontFamily: 'Nunito_700Bold',
-    },
     snackLabel: {
       color: theme.colors.background,
       fontSize: 16,
-      fontFamily: 'Nunito_700Bold',
-    },
-    deleteButtonLabel: {
-      color: theme.colors.text,
-      fontSize: 18,
       fontFamily: 'Nunito_700Bold',
     },
     catLadyImage: {
@@ -600,29 +565,21 @@ export const HotspotFormScreen = ({
                 }}
               >
                 {isUpdate && (
-                  <Button
-                    uppercase={false}
-                    style={styles.deleteButton}
-                    contentStyle={styles.saveButtonContent}
-                    labelStyle={styles.deleteButtonLabel}
-                    icon="close"
-                    mode="contained"
+                  <NucaFormButton
+                    label="Șterge adresa"
+                    iconName="close"
+                    backgroundColor={theme.colors.surface}
+                    labelColor={theme.colors.text}
                     onPress={deleteH}
-                  >
-                    Șterge adresa
-                  </Button>
+                  />
                 )}
-                <Button
-                  uppercase={false}
-                  style={styles.saveButton}
-                  contentStyle={styles.saveButtonContent}
-                  labelStyle={styles.saveButtonLabel}
-                  icon="check"
-                  mode="contained"
+                <NucaFormButton
+                  label="Salvează"
+                  iconName="check"
+                  backgroundColor={theme.colors.primary}
+                  labelColor={theme.colors.background}
                   onPress={saveAndNavigateToDetailScreen}
-                >
-                  Salvează
-                </Button>
+                />
               </View>
             </View>
           </View>

--- a/screens/ReportGenerationScreen.tsx
+++ b/screens/ReportGenerationScreen.tsx
@@ -1,35 +1,18 @@
 import { useState } from 'react';
 import { ScrollView, StyleSheet, View } from 'react-native';
-import { Button, Caption, Headline, Icon } from 'react-native-paper';
+import { Caption, Headline, Icon } from 'react-native-paper';
 import { DatePickerInput } from 'react-native-paper-dates';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Appbar } from '../components/Appbar';
 import { FooterScreens, FooterView } from '../components/Footer';
 import { FullScreenActivityIndicator } from '../components/FullScreenActivityIndicator';
+import { NucaFormButton } from '../components/NucaFormButton';
 import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
 import { RootStackParamList } from '../types';
 import { isSmallScreen } from '../utils/helperFunc';
 
 const getStyles = (theme: NucaCustomTheme) =>
   StyleSheet.create({
-    saveButton: {
-      height: 64,
-      maxWidth: 340,
-      minWidth: isSmallScreen() ? 64 : 340,
-    },
-    saveButtonContent: {
-      height: 64,
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexDirection: 'row-reverse',
-    },
-    saveButtonLabel: {
-      fontSize: 18,
-      marginStart: 8,
-      textAlignVertical: 'bottom',
-      fontFamily: 'Nunito_700Bold',
-      color: theme.colors.background,
-    },
     loadingContainer: {
       flex: 1,
       justifyContent: 'center',
@@ -151,17 +134,13 @@ export const ReportGenerationScreen = (
                 marginTop: 54,
               }}
             >
-              <Button
-                uppercase={false}
-                style={styles.saveButton}
-                contentStyle={styles.saveButtonContent}
-                labelStyle={styles.saveButtonLabel}
-                icon="file-document-outline"
-                mode="contained"
+              <NucaFormButton
+                label="Generează raport"
+                backgroundColor={theme.colors.primary}
+                labelColor={theme.colors.background}
+                iconName="file-document-outline"
                 onPress={() => {}}
-              >
-                Generează raport
-              </Button>
+              />
             </View>
           </View>
           <FooterView screen={FooterScreens.ReportGenerationScreen} />

--- a/screens/ReportGenerationScreen.tsx
+++ b/screens/ReportGenerationScreen.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import { Button, Caption, Headline, Icon } from 'react-native-paper';
+import { DatePickerInput } from 'react-native-paper-dates';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { Appbar } from '../components/Appbar';
+import { FooterScreens, FooterView } from '../components/Footer';
+import { FullScreenActivityIndicator } from '../components/FullScreenActivityIndicator';
+import { useNucaTheme as useTheme } from '../hooks/useNucaTheme';
+import { RootStackParamList } from '../types';
+import { isSmallScreen } from '../utils/helperFunc';
+
+const getStyles = (theme: NucaCustomTheme) =>
+  StyleSheet.create({
+    saveButton: {
+      height: 64,
+      maxWidth: 340,
+      minWidth: isSmallScreen() ? 64 : 340,
+    },
+    saveButtonContent: {
+      height: 64,
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'row-reverse',
+    },
+    saveButtonLabel: {
+      fontSize: 18,
+      marginStart: 8,
+      textAlignVertical: 'bottom',
+      fontFamily: 'Nunito_700Bold',
+      color: theme.colors.background,
+    },
+    loadingContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    container: {
+      backgroundColor: theme.colors.background,
+      flex: 1,
+    },
+    scrollView: {
+      width: '100%',
+      height: '1000%',
+    },
+    contentContainer: {
+      padding: 20,
+      width: isSmallScreen() ? '100%' : '85%',
+    },
+    screenTitleContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    screenTitleIcon: {
+      fontSize: 28,
+      fontFamily: 'Nunito_700Bold',
+      color: theme.colors.text,
+    },
+    screenTitleLabel: {
+      fontSize: 18,
+      marginStart: 8,
+      textAlignVertical: 'bottom',
+      fontFamily: 'Nunito_700Bold',
+      color: theme.colors.text,
+    },
+    pickerContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flexWrap: 'wrap',
+    },
+    datePickerContainer: {
+      width: '50%',
+      flexDirection: 'column',
+      justifyContent: 'flex-start',
+      alignItems: 'flex-start',
+      padding: 4,
+    },
+    textInputTitle: {
+      color: theme.colors.text,
+      fontSize: 12,
+      marginTop: 20,
+      fontFamily: 'Nunito_700Bold',
+      textTransform: 'uppercase',
+    },
+    titleRow: {
+      flexDirection: 'row',
+      alignItems: 'baseline',
+      paddingBottom: 12,
+    },
+  });
+
+export const ReportGenerationScreen = (
+  _params: NativeStackScreenProps<RootStackParamList, 'ReportGeneration'>
+) => {
+  const theme = useTheme();
+  const styles = getStyles(theme);
+  const [isInProgress, _setIsInProgress] = useState(false);
+
+  return (
+    <>
+      <Appbar forDetailScreen />
+      <View style={styles.container}>
+        <ScrollView style={styles.scrollView}>
+          <View
+            style={{
+              alignItems: 'center',
+            }}
+          >
+            <View style={styles.contentContainer}>
+              <View style={styles.screenTitleContainer}>
+                <View style={styles.titleRow}>
+                  <Headline style={styles.screenTitleIcon}>
+                    <View>
+                      <Icon source={'file-document-outline'} size={22} />
+                    </View>
+                  </Headline>
+                  <Caption style={styles.screenTitleLabel}>
+                    Generează raport
+                  </Caption>
+                </View>
+              </View>
+
+              <View style={styles.pickerContainer}>
+                <View style={styles.datePickerContainer}>
+                  <Caption style={styles.textInputTitle}>De la</Caption>
+                  <DatePickerInput
+                    locale="en"
+                    value={new Date()}
+                    onChange={_selectedDate => {}}
+                    mode="outlined"
+                    inputMode="start"
+                    withDateFormatInLabel={false}
+                    outlineColor={theme.colors.disabled}
+                  />
+                </View>
+                <View style={styles.datePickerContainer}>
+                  <Caption style={styles.textInputTitle}>Până la</Caption>
+                  <DatePickerInput
+                    locale="en"
+                    value={new Date()}
+                    onChange={_selectedDate => {}}
+                    mode="outlined"
+                    inputMode="start"
+                    withDateFormatInLabel={false}
+                    outlineColor={theme.colors.disabled}
+                  />
+                </View>
+              </View>
+
+              <View
+                style={{
+                  justifyContent: 'flex-end',
+                  flexDirection: isSmallScreen() ? 'column' : 'row',
+                  marginTop: 54,
+                }}
+              >
+                <Button
+                  uppercase={false}
+                  style={styles.saveButton}
+                  contentStyle={styles.saveButtonContent}
+                  labelStyle={styles.saveButtonLabel}
+                  icon="file-document-outline"
+                  mode="contained"
+                  onPress={() => {}}
+                >
+                  Generează raport
+                </Button>
+              </View>
+            </View>
+          </View>
+          <FooterView screen={FooterScreens.ReportGenerationScreen} />
+        </ScrollView>
+      </View>
+      {isInProgress && <FullScreenActivityIndicator />}
+    </>
+  );
+};

--- a/screens/ReportGenerationScreen.tsx
+++ b/screens/ReportGenerationScreen.tsx
@@ -44,8 +44,10 @@ const getStyles = (theme: NucaCustomTheme) =>
       height: '1000%',
     },
     contentContainer: {
+      alignItems: 'stretch',
       padding: 20,
       width: isSmallScreen() ? '100%' : '85%',
+      marginLeft: isSmallScreen() ? 0 : '7.5%',
     },
     screenTitleContainer: {
       flexDirection: 'row',
@@ -84,7 +86,7 @@ const getStyles = (theme: NucaCustomTheme) =>
     },
     titleRow: {
       flexDirection: 'row',
-      alignItems: 'baseline',
+      alignItems: 'center',
       paddingBottom: 12,
     },
   });
@@ -101,71 +103,65 @@ export const ReportGenerationScreen = (
       <Appbar forDetailScreen />
       <View style={styles.container}>
         <ScrollView style={styles.scrollView}>
-          <View
-            style={{
-              alignItems: 'center',
-            }}
-          >
-            <View style={styles.contentContainer}>
-              <View style={styles.screenTitleContainer}>
-                <View style={styles.titleRow}>
-                  <Headline style={styles.screenTitleIcon}>
-                    <View>
-                      <Icon source={'file-document-outline'} size={22} />
-                    </View>
-                  </Headline>
-                  <Caption style={styles.screenTitleLabel}>
-                    Generează raport
-                  </Caption>
-                </View>
-              </View>
-
-              <View style={styles.pickerContainer}>
-                <View style={styles.datePickerContainer}>
-                  <Caption style={styles.textInputTitle}>De la</Caption>
-                  <DatePickerInput
-                    locale="en"
-                    value={new Date()}
-                    onChange={_selectedDate => {}}
-                    mode="outlined"
-                    inputMode="start"
-                    withDateFormatInLabel={false}
-                    outlineColor={theme.colors.disabled}
-                  />
-                </View>
-                <View style={styles.datePickerContainer}>
-                  <Caption style={styles.textInputTitle}>Până la</Caption>
-                  <DatePickerInput
-                    locale="en"
-                    value={new Date()}
-                    onChange={_selectedDate => {}}
-                    mode="outlined"
-                    inputMode="start"
-                    withDateFormatInLabel={false}
-                    outlineColor={theme.colors.disabled}
-                  />
-                </View>
-              </View>
-
-              <View
-                style={{
-                  justifyContent: 'flex-end',
-                  flexDirection: isSmallScreen() ? 'column' : 'row',
-                  marginTop: 54,
-                }}
-              >
-                <Button
-                  uppercase={false}
-                  style={styles.saveButton}
-                  contentStyle={styles.saveButtonContent}
-                  labelStyle={styles.saveButtonLabel}
-                  icon="file-document-outline"
-                  mode="contained"
-                  onPress={() => {}}
-                >
+          <View style={styles.contentContainer}>
+            <View style={styles.screenTitleContainer}>
+              <View style={styles.titleRow}>
+                <Headline style={styles.screenTitleIcon}>
+                  <View>
+                    <Icon source={'file-document-outline'} size={22} />
+                  </View>
+                </Headline>
+                <Caption style={styles.screenTitleLabel}>
                   Generează raport
-                </Button>
+                </Caption>
               </View>
+            </View>
+
+            <View style={styles.pickerContainer}>
+              <View style={styles.datePickerContainer}>
+                <Caption style={styles.textInputTitle}>De la</Caption>
+                <DatePickerInput
+                  locale="en"
+                  value={new Date()}
+                  onChange={_selectedDate => {}}
+                  mode="outlined"
+                  inputMode="start"
+                  withDateFormatInLabel={false}
+                  outlineColor={theme.colors.disabled}
+                />
+              </View>
+              <View style={styles.datePickerContainer}>
+                <Caption style={styles.textInputTitle}>Până la</Caption>
+                <DatePickerInput
+                  locale="en"
+                  value={new Date()}
+                  onChange={_selectedDate => {}}
+                  mode="outlined"
+                  inputMode="start"
+                  withDateFormatInLabel={false}
+                  outlineColor={theme.colors.disabled}
+                />
+              </View>
+            </View>
+
+            <View
+              style={{
+                justifyContent: 'flex-end',
+                flexDirection: isSmallScreen() ? 'column' : 'row',
+                marginTop: 54,
+              }}
+            >
+              <Button
+                uppercase={false}
+                style={styles.saveButton}
+                contentStyle={styles.saveButtonContent}
+                labelStyle={styles.saveButtonLabel}
+                icon="file-document-outline"
+                mode="contained"
+                onPress={() => {}}
+              >
+                Generează raport
+              </Button>
             </View>
           </View>
           <FooterView screen={FooterScreens.ReportGenerationScreen} />

--- a/screens/ReportGenerationScreen.tsx
+++ b/screens/ReportGenerationScreen.tsx
@@ -24,13 +24,19 @@ const getStyles = (theme: NucaCustomTheme) =>
     },
     scrollView: {
       width: '100%',
-      height: '1000%',
+      height: '100%',
+    },
+    scrollViewContentContainer: {
+      flexGrow: 1,
+      justifyContent: 'flex-end',
     },
     contentContainer: {
       alignItems: 'stretch',
       padding: 20,
       width: isSmallScreen() ? '100%' : '85%',
       marginLeft: isSmallScreen() ? 0 : '7.5%',
+      position: 'relative',
+      zIndex: 1,
     },
     screenTitleContainer: {
       flexDirection: 'row',
@@ -85,7 +91,11 @@ export const ReportGenerationScreen = (
     <>
       <Appbar forDetailScreen />
       <View style={styles.container}>
-        <ScrollView style={styles.scrollView}>
+        <ScrollView
+          scrollEnabled={false}
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollViewContentContainer}
+        >
           <View style={styles.contentContainer}>
             <View style={styles.screenTitleContainer}>
               <View style={styles.titleRow}>

--- a/types.tsx
+++ b/types.tsx
@@ -37,6 +37,7 @@ export type RootStackParamList = {
   HotspotDetail: { hotspotId: string };
   NotFound: undefined;
   ChooseLocation: { region: Region; location?: Location };
+  ReportGeneration: undefined;
 };
 
 export type RootStackScreenProps<Screen extends keyof RootStackParamList> =


### PR DESCRIPTION
## Changes

- the newly created screen
- fix: the menu dropdown from the upper app bar was not closed after selecting an item
- fix: banner images displayed at the bottom of the HotspotForm and ReportGeneration screens did not fit the whole width of the device screen on the web platform

## Demo

### iOS

https://github.com/crafting-software/nuca-mobile/assets/32801760/728e706a-bf69-4360-9d8f-0daf3503c2d8

### Android

https://github.com/crafting-software/nuca-mobile/assets/32801760/38eb741b-3a01-4876-95c8-0cdc21b3a632

### Web

https://github.com/crafting-software/nuca-mobile/assets/32801760/7341b475-6939-42da-86f4-94f12651f2fa
