### PR TITLE
FIX: Cat card volunteer name update issue

### DIFF
--- a/components/AddCatCard.tsx
+++ b/components/AddCatCard.tsx
@@ -318,7 +318,7 @@ export const AddCatCard = ({
   const saveCat = async () => {
     if (saveChanges) saveChanges();
     if (isEditingMode) {
-      const { success, cat } = await updateCat(
+      const { success, cat: savedCat } = await updateCat(
         checked
           ? {
               ...localCat,
@@ -326,12 +326,16 @@ export const AddCatCard = ({
             }
           : localCat
       );
-      if (success && cat) {
+
+      if (success && cat && savedCat) {
         SnackbarManager.success('Cat updated!');
         if (checked) {
           setHotspotDetails(prev => ({
             ...prev,
-            sterilizedCats: [cat, ...hotspotDetails.sterilizedCats],
+            sterilizedCats: [
+              { ...savedCat, isSterilized: true },
+              ...hotspotDetails.sterilizedCats,
+            ],
             unsterilizedCats: hotspotDetails.unsterilizedCats.filter(
               (c: Cat) => c.id !== cat.id
             ),
@@ -342,7 +346,7 @@ export const AddCatCard = ({
             : hotspotDetails.unsterilizedCats;
           const catIndex = catList.findIndex((c: Cat) => c.id === cat.id);
           catList[catIndex] = localCat;
-          cat.isSterilized
+          localCat.isSterilized
             ? setHotspotDetails(prev => ({
                 ...prev,
                 sterilizedCats: catList,

--- a/components/AddCatCard.tsx
+++ b/components/AddCatCard.tsx
@@ -316,50 +316,61 @@ export const AddCatCard = ({
     deleteCat(localCat);
 
   const saveCat = async () => {
-    if (saveChanges) saveChanges();
-    if (isEditingMode) {
-      const { success, cat: savedCat } = await updateCat(
-        checked
-          ? {
-              ...localCat,
-              isSterilized: checked,
-            }
-          : localCat
-      );
+    saveChanges && saveChanges();
 
-      if (success && cat && savedCat) {
-        SnackbarManager.success('Cat updated!');
-        if (checked) {
-          setHotspotDetails(prev => ({
-            ...prev,
-            sterilizedCats: [
-              { ...savedCat, isSterilized: true },
-              ...hotspotDetails.sterilizedCats,
-            ],
-            unsterilizedCats: hotspotDetails.unsterilizedCats.filter(
-              (c: Cat) => c.id !== cat.id
-            ),
-          }));
-        } else {
-          const catList = cat.isSterilized
-            ? hotspotDetails.sterilizedCats
-            : hotspotDetails.unsterilizedCats;
-          const catIndex = catList.findIndex((c: Cat) => c.id === cat.id);
-          catList[catIndex] = localCat;
-          localCat.isSterilized
-            ? setHotspotDetails(prev => ({
-                ...prev,
-                sterilizedCats: catList,
-              }))
-            : setHotspotDetails(prev => ({
-                ...prev,
-                unsterilizedCats: catList,
-              }));
-        }
-      }
-    } else {
-      if (addCat) addCat(localCat);
+    if (!isEditingMode) {
+      addCat && addCat(localCat);
+      return;
     }
+
+    const { success, cat: savedCat } = await updateCat(
+      checked
+        ? {
+            ...localCat,
+            isSterilized: checked,
+          }
+        : localCat
+    );
+
+    if (!success || !cat || !savedCat) {
+      SnackbarManager.error(
+        'AddCatCard - saveCat request',
+        'Informațiile pisicii nu au putut fi actualizate. Verificǎ dacǎ dispozitivul tãu este conectat la internet.'
+      );
+      return;
+    }
+
+    SnackbarManager.success('Cat updated!');
+
+    if (checked) {
+      setHotspotDetails(prev => ({
+        ...prev,
+        sterilizedCats: [
+          { ...savedCat, isSterilized: true },
+          ...hotspotDetails.sterilizedCats,
+        ],
+        unsterilizedCats: hotspotDetails.unsterilizedCats.filter(
+          (c: Cat) => c.id !== cat.id
+        ),
+      }));
+
+      return;
+    }
+
+    const catList = cat.isSterilized
+      ? hotspotDetails.sterilizedCats
+      : hotspotDetails.unsterilizedCats;
+    const catIndex = catList.findIndex((c: Cat) => c.id === cat.id);
+    catList[catIndex] = localCat;
+    localCat.isSterilized
+      ? setHotspotDetails(prev => ({
+          ...prev,
+          sterilizedCats: catList,
+        }))
+      : setHotspotDetails(prev => ({
+          ...prev,
+          unsterilizedCats: catList,
+        }));
   };
 
   const [visible, setVisible] = useState(false);

--- a/utils/cats.ts
+++ b/utils/cats.ts
@@ -36,11 +36,9 @@ export const updateCat = async (
     sendAsFormData: true,
   });
 
-  if (error) {
-    console.error('update cat failed', error);
-    return { success: false };
-  }
-  return { success: true, cat: castToCat(data.data) };
+  return error
+    ? { success: false }
+    : { success: true, cat: castToCat(data.data) };
 };
 
 export const deleteCatRequest = async (


### PR DESCRIPTION
## Changes

Before including these changes, updates for the name of a volunteer associated with an unsterilized cat card are not displayed immediately. Unfortunately, attempting to use Repo.preload to fix this does not work as expected. The update has to be forced by inserting the new volunteer values into the returned entity.

Check out the nuca-backend PR as well: https://github.com/crafting-software/nuca-backend/pull/29

## Demo

### Before

https://github.com/crafting-software/nuca-mobile/assets/32801760/990e0b83-2851-4ffc-821b-afaf4df0fcbe

### After

https://github.com/crafting-software/nuca-mobile/assets/32801760/4a3ff657-15c7-4cef-8641-618952796964

